### PR TITLE
Update PathFinderModal experimental feature warning for clarity

### DIFF
--- a/my-app/src/components/StateMachineVisualizer/PathFinderModal.jsx
+++ b/my-app/src/components/StateMachineVisualizer/PathFinderModal.jsx
@@ -277,7 +277,7 @@ export default function PathFinderModal({ states, onClose }) {
 
           <div className="mb-6 p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg">
             <p className="text-sm text-yellow-800 dark:text-yellow-200">
-              ⚠️ Experimental Feature: This path finding functionality is currently in beta.
+              ⚠️ Experimental Feature: Find all possible paths between states.
             </p>
           </div>
         </div>


### PR DESCRIPTION
- Revised the warning message to specify that the pathfinding functionality allows users to find all possible paths between states, enhancing user understanding of the feature's purpose. This change aims to provide clearer communication regarding the experimental nature of the feature.